### PR TITLE
Fix bug where feature extraction fails if we have few points in a polygon

### DIFF
--- a/sunycell/features.py
+++ b/sunycell/features.py
@@ -13,6 +13,9 @@ def get_polygon_from_pts(pts):
         X = pt[0]
         Y = pt[1]
         point_list = [(x,y) for x,y in zip(X,Y)]
+        if len(point_list) < 3:
+            # Simply continue on to the next set of X,Y coordinates
+            continue
         poly = Polygon(point_list)
         polygons.append(poly)
     return polygons


### PR DESCRIPTION
Thanks @rakesh7009. 

This fixes #1 and will silently continue to the next set of points if there are fewer than 3 in the current point list.

If all of the elements in `pts` are less than 3, we will end up skipping everything and returning an empty array.

Not sure if this should return `None` or print a warning, instead of silently returning an empty array.

@rakesh7009, can you pull this branch down and check if this solves the issue?